### PR TITLE
Allow mentioning roles and users by default.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ const client = new Client({
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.GuildMessageReactions,
   ],
+  allowedMentions: {
+    parse: ['roles', 'users'],
+  },
 });
 
 client.commands = new Collection();


### PR DESCRIPTION
Add 'roles' and 'users' to BaseMessageOptions.allowedMentions by default for all messages. This should allow the bot to ping the @Dooters role.